### PR TITLE
Changes for Mura 6.2 installation

### DIFF
--- a/plugin/config.xml.cfm
+++ b/plugin/config.xml.cfm
@@ -32,6 +32,10 @@ http://www.apache.org/licenses/LICENSE-2.0
 					persist="false" />
 		</eventHandlers>
 
+		<!-- Required for Mura 6.2 installation -->
+		<displayobjects></displayobjects>
+		<settings></settings>
+
 		<extensions>
 			<extension type="Base" subtype="Default">
 				<attributeset name="Google Sitemaps">


### PR DESCRIPTION
I had to add the "displayobjects" and "settings" attributes for the installation to run on Mura version 6.2.  Otherwise an error was being thrown.

I also had to change the app reload key "variables.framework.password" in the "\includes\fw1config.cfm" file.  While it is mentioned within that file in a comment, it is not mentioned in the installation notes.  You should probably add a note about it there as well for those of us who have changed from the default app reload key.

I see you already set those other debug variables to "false".  That is good.

Another note about installation, you mention if you already have the older plugin installed to un-install it first.  That is fine but it does not clean up any of the already existing entries/class extensions.  The old plugin created class extensions forf the "Page / Default", "File / Default", "Calendar / Default", "Gallery / Default", "Portal / Default", "Folder / Default" and "Custom / MeldGoogleSitemaps" levels.  The new plugin only creates one: "Base / Default".  Those others should be deleted to avoid confusion and also aid processing time (as those entries are still in the database).  The existing scheduled task for the old plugin also needs to be deleted.

These are my notes regarding installing the new plugin on Mura 6.2.  Feel free to use these or discard these as you wish.