### PR TITLE
Changes for running plugin in Mura 6.2

### DIFF
--- a/Application.cfc
+++ b/Application.cfc
@@ -29,7 +29,7 @@ component persistent="false" accessors="true" output="false" extends="includes.f
 		include this.muraAppConfigPath & 'appcfc/applicationSettings.cfm';
 	} else {
 		// Pre 7.1
-		this.muraAppConfigPath = local.includeroot & 'config';
+		this.muraAppConfigPath = local.includeroot & 'config/';
 		include local.includeroot & 'config/applicationSettings.cfm';
 
 		try {
@@ -132,10 +132,18 @@ component persistent="false" accessors="true" output="false" extends="includes.f
 
 		param name='request.context.siteid' default='';
 
+		setting requesttimeout="60"; // extend the request timeout for this
 		if ( !StructKeyExists(session, 'siteid') ) {
-			lock scope='session' type='exclusive' timeout='10' {
-				session.siteid = 'default';
-			};
+			// Session is not setup when running from the scheduler
+			if (StructKeyExists(url,"site")) {
+				lock scope='session' type='exclusive' timeout='10' {
+					session.siteid = url.site;
+				};
+			} else {
+				lock scope='session' type='exclusive' timeout='10' {
+					session.siteid = 'default';
+				};
+			}
 		}
 
 		secureRequest();


### PR DESCRIPTION
Ran into several issues while attempting to run this plugin on Mura 6.2. Changes for this file:

Added a trailing slash to the "this.muraAppConfigPath" variable in the pre 7.1 section.

Added setting of the request timeout to extend it. This process takes a long time on a server with several pages.  I set it to 60 seconds here but it was taking over 1.5 hours on our production server. It will need to be set per installation or configurable perhaps.

Added setting of the "session.siteid" because it was being set to "default" when running from the scheduled task.  I assume the session does not exist when running from the scheduler.  The condition checks for the default setting, and if true then check to see if the "url.site" has been set and uses that.  Otherwise stick with "default".