### PR TITLE
Changes for running plugin in Mura 6.2

### DIFF
--- a/process/controllers/main.cfc
+++ b/process/controllers/main.cfc
@@ -41,7 +41,7 @@ component persistent="false" accessors="true" output="false" extends="controller
 			fileWrite(filename,sitemapXML);
 		}
 		catch(any e) {
-			writeDump(e);abort;
+			// writeDump(e);abort;
 			if(rc.gsmsettings.getValue('location') eq "web") {
 				filename = expandPath("../../sitemap.xml");
 			}
@@ -62,8 +62,8 @@ component persistent="false" accessors="true" output="false" extends="controller
 					siteConfig.getContactEmail() );
 			}
 			catch( any e ) {
-					writeDump(e);
-					abort;
+					// writeDump(e);
+					// abort;
 			}
 		}
 


### PR DESCRIPTION
I see that you have fixed several of the things that I ran into here; using fileWrite(), getting the value of "notifyemail" instead of "email". The only other thing I would suggest is not dumping and aborting. The catch already has some error handling to write the output file.  Unless you found some other issue there.  Probably same for if the email fails.