### PR TITLE
Speed up the indexing process

### DIFF
--- a/model/manager/googlesitemapsmanager.cfc
+++ b/model/manager/googlesitemapsmanager.cfc
@@ -96,6 +96,30 @@
 				ON
 					tclassextendattributes.attributeID = tclassextenddata.attributeID
 			JOIN
+				tcontent
+				ON
+					tclassextendattributes.attributeID = tclassextenddata.attributeID
+				AND
+					tclassextenddata.baseID = tcontent.contentHistID
+				AND
+					tcontent.approved = 1
+				AND
+					tcontent.active = 1
+				AND
+					(
+					tcontent.display = 1
+					OR
+						(
+							tcontent.display = 2
+							AND
+							<cfif application.configBean.getDbType() eq "mysql">
+								tcontent.displaystart <= CURDATE()
+							<cfelse>
+								tcontent.displaystart <= #CreateODBCDateTime( now() )#
+							</cfif>
+						)
+					)
+			JOIN
 				tclassextendsets
 				ON
 					tclassextendsets.extendSetID = tclassextendattributes.extendSetID


### PR DESCRIPTION
On our site of roughly 5,000 pages this plugin was taking over 1.5 hours to run.  With the suggested edit the process now takes around 30 minutes.  Basically the change is to only loop over approved and active pages.  In our environment, before the change the qAtts query was returning 43,165 rows.  After the change it only returns 12,469 rows.  The resulting sitemap.xml file is identical in our environment.  Please verify and confirm in your environment.