### PR TITLE
Change for running under ColdFusion 2018

### DIFF
--- a/model/manager/googlesitemapsmanager.cfc
+++ b/model/manager/googlesitemapsmanager.cfc
@@ -41,7 +41,6 @@
 				startdate="#dateFormat(now(),"mm/dd/yy")#"
 				starttime="#timeFormat( timeOfDay,"hh:mm TT" )#"
 				resolveurl="true"
-				requesttimeout="1000"
 				>
 		<cfelse>
 			<cfschedule


### PR DESCRIPTION
The `requesttimeout` setting is not supported for the `<cfschedule>` tag.